### PR TITLE
Fix Vercel build: remove deprecated eslint config, add --no-lint to b…

### DIFF
--- a/adminweb/next.config.ts
+++ b/adminweb/next.config.ts
@@ -5,9 +5,6 @@ const nextConfig: NextConfig = {
   experimental: {
     webpackBuildWorker: true
   },
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
 };
 
 export default nextConfig;

--- a/adminweb/package.json
+++ b/adminweb/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "build": "next build --turbopack --no-lint",
     "start": "next start",
     "lint": "eslint"
   },


### PR DESCRIPTION
…uild

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build configuration-only change; main risk is reduced enforcement of lint checks during builds if CI doesn’t run `lint` separately.
> 
> **Overview**
> Removes the `eslint.ignoreDuringBuilds` override from `adminweb/next.config.ts`.
> 
> Updates the `adminweb` `build` script to run `next build --turbopack --no-lint`, preserving the ability to run linting separately via `npm run lint` while unblocking CI/Vercel builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8cdc3ab34d7fbf7719dd212747a7e9ade19edbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->